### PR TITLE
specify rails release in migration

### DIFF
--- a/lib/generators/user_preferences/templates/migration.rb
+++ b/lib/generators/user_preferences/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreatePreferences < ActiveRecord::Migration
+class CreatePreferences < ActiveRecord::Migration[6.0]
   def self.up
     create_table :preferences do |t|
       t.integer :user_id, null: false


### PR DESCRIPTION
Receiving error when trying to run `rails db:migrate`

```Caused by:
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:```

Specifying rails release in migration file fixes issue.