### PR TITLE
Ruby 3.2.0 change to pattern-matching operator

### DIFF
--- a/lib/user_preferences/preference_definition.rb
+++ b/lib/user_preferences/preference_definition.rb
@@ -37,10 +37,10 @@ module UserPreferences
 
     def to_bool(value)
       return true if value == 1
-      return true if value == true || value =~ (/^(true|t|yes|y|1)$/i)
+      return true if value == true || value.to_s =~ (/^(true|t|yes|y|1)$/i)
 
       return false if value == 0
-      return false if value == false || value.blank? || value =~ (/^(false|f|no|n|0)$/i)
+      return false if value == false || value.blank? || value.to_s =~ (/^(false|f|no|n|0)$/i)
       raise ArgumentError.new("invalid value for Boolean: \"#{value}\"")
     end
   end


### PR DESCRIPTION
The pattern-matching operator no longer is available for a false or true object. Previously it would return nil when called on the FalseClass or TrueClass, but with 3.2.0, it returns `NoMethodError: undefined method =~ for false:FalseClass`

To correct for this, we can change the true or false object to a string before checking this string against the regex.