### PR TITLE
Don't attempt to call `=~` on Integer values

### DIFF
--- a/lib/user_preferences/preference_definition.rb
+++ b/lib/user_preferences/preference_definition.rb
@@ -37,10 +37,10 @@ module UserPreferences
 
     def to_bool(value)
       return true if value == 1
-      return true if value == true || value =~ (/^(true|t|yes|y|1)$/i)
+      return true if value == true || value.to_s =~ (/^(true|t|yes|y|1)$/i)
 
       return false if value == 0
-      return false if value == false || value.blank? || value =~ (/^(false|f|no|n|0)$/i)
+      return false if value == false || value.blank? || value.to_s =~ (/^(false|f|no|n|0)$/i)
       raise ArgumentError.new("invalid value for Boolean: \"#{value}\"")
     end
   end


### PR DESCRIPTION
In Ruby 3.2, this method is no longer available on integers. We can avoid the comparison entirely by turning the value for comparison into a String.

We could also have moved the comparison to `0` above the other lines, but this would not have handled the situation where we are given another Integer value (or another class).

Thanks to https://github.com/billabel for this fix!