### PR TITLE
Add backwards compatibility option for non-binary options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ emails:
   newsletters: false
 ```
 
+Binary preferences can be enhanced to support multiple values while maintaining backwards compatibility on the API side:
+
+```yaml
+emails:
+  notifications:
+    default: true
+    acts_as_binary: true
+    values:
+      - false
+      - true
+      - email
+      - push
+```
+
+This will support setting the preference using integers, booleans, and strings for the first 2 values.
+
 You can add as many categories as you like:
 
 ```yaml

--- a/spec/fixtures/user_preferences.yml
+++ b/spec/fixtures/user_preferences.yml
@@ -17,3 +17,12 @@ food:
       - red
       - white
 
+notifications:
+  followed_user:
+    acts_as_binary: true
+    default: true
+    values:
+      - false
+      - true
+      - email
+      - push

--- a/spec/user_preferences/defaults_spec.rb
+++ b/spec/user_preferences/defaults_spec.rb
@@ -16,6 +16,9 @@ describe UserPreferences::Defaults do
             a_la_carte: true,
             courses: 2,
             wine: 'red'
+          },
+          notifications: {
+            followed_user: true
           }
         }
       )

--- a/spec/user_preferences/preference_definition_spec.rb
+++ b/spec/user_preferences/preference_definition_spec.rb
@@ -87,4 +87,36 @@ describe UserPreferences::PreferenceDefinition do
       end
     end
   end
+
+  context 'non-binary preference acting as binary' do
+    subject(:preference) do
+      definition = UserPreferences.definitions[:notifications][:followed_user]
+      UserPreferences::PreferenceDefinition.new(definition, :notifications, :followed_user)
+    end
+
+    describe '#binary?' do
+      it 'is false' do
+        expect(preference.binary?).to eq(false)
+      end
+    end
+
+    describe '#default' do
+      it 'returns the default preference value' do
+        expect(preference.default).to eq(true)
+      end
+    end
+
+    describe '#to_db' do
+      it 'casts the first 2 values to booleans' do
+        expect(preference.to_db(0)).to eq(0)
+        expect(preference.to_db(1)).to eq(1)
+        expect(preference.to_db(2)).to eq(nil)
+      end
+
+      it 'casts true/false strings to booleans' do
+        expect(preference.to_db('false')).to eq(0)
+        expect(preference.to_db('true')).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
One can set binary true/false preferences the following way:
```
- set(preference: 0) -> false
- set(preference: 1) -> true
- set(preference: false) -> false
- set(preference: true) -> true
- set(preference: 'false') -> false
- set(preference: 'true') -> true
```

With a non-binary preference containing `false` and `true` this isn't possible anymore, as the preference logic will refuse to cast the given value to a boolean.

This is intended and useful for the most part, but there are cases where we want to keep the casting behavior for non-binary preferences as well.

Add a `acts_as_binary` option which when set to true will attempt to cast the given value to a boolean. If the cast succeeds, the boolean is returned. If not, the given value is returned.

This would allow non-binary preferences to be set like binary preferences for the `true` and `false` boolean values.